### PR TITLE
refactor arabic_chars & ad_commas module

### DIFF
--- a/src/arabic_chars/mod.rs
+++ b/src/arabic_chars/mod.rs
@@ -1,26 +1,18 @@
 use std::borrow::Cow;
 
-pub mod chars {
-    pub static AR_NUMBER: &str = "٠١٢٣٤٥٦٧٨٩"; // tick
-    pub static AR_TEXT: &str =
-        "ابتثجحخدذرزسشصضطظعغفقكلمنهويآةى؟ؠءأؤإ ؘ ؙ ؚ؛ ً ٌ ٍ َ ُ ِ ّ ْ ٓ ٔ ٕ ٖ ٗ ٘ ٙ ٚ ٛ ٝ ٞ ٟ٠١٢٣٤٥٦٧٨٩";
-}
+const AR_TEXT: &str = "ابتثجحخدذرزسشصضطظعغفقكلمنهويآةى؟ؠءأؤإ ؘ ؙ ؚ؛ ً ٌ ٍ َ ُ ِ ّ ْ ٓ ٔ ٕ ٖ ٗ ٘ ٙ ٚ ٛ ٝ ٞ ٟ٠١٢٣٤٥٦٧٨٩";
 
 /// Return true if the entered string includes arabic characters
 pub fn has_arabic(input: impl AsRef<str>) -> bool {
     input
         .as_ref()
         .chars()
-        .any(|char| char != ' ' && chars::AR_TEXT.contains(char))
+        .any(|char| char != ' ' && AR_TEXT.contains(char))
 }
 
 /// Return true if the entered string does not include other-language characters.
 pub fn is_arabic(input: impl AsRef<str>) -> bool {
-    !input.as_ref().is_empty()
-        && input
-            .as_ref()
-            .chars()
-            .all(|char| chars::AR_TEXT.contains(char))
+    !input.as_ref().is_empty() && input.as_ref().chars().all(|char| AR_TEXT.contains(char))
 }
 
 /// Description: Replaces all instances of ی and ک with  ي and ك,

--- a/src/commas/add_commas.rs
+++ b/src/commas/add_commas.rs
@@ -18,28 +18,26 @@
 ///     }
 /// }
 /// ```
-pub fn add_commas(inp: impl AsRef<str>) -> String {
-    let inp = inp.as_ref();
-    let comma_less = |c: &char| c != &',';
+pub fn add_commas(number_str: impl AsRef<str>) -> String {
+    let number_str = number_str.as_ref().replace(",", ""); // Remove existing commas
 
-    let mut end = inp
+    let dot_index = number_str.find('.').unwrap_or(number_str.len());
+
+    let result = number_str[..dot_index]
         .chars()
-        .filter(comma_less)
-        .position(|c| c == '.')
-        .unwrap_or_else(|| inp.chars().filter(comma_less).count());
-
-    let mut result = String::new();
-    for (i, ch) in inp.chars().filter(comma_less).enumerate() {
-        if end == i {
-            end += inp.chars().filter(|c| c == &',').count();
-            result.push_str(&inp[end..inp.chars().count()]);
-            break;
-        }
-        if (end - i) % 3 == 0 && i != 0 {
-            result.push(',')
-        }
-        result.push(ch);
-    }
+        .rev()
+        .enumerate()
+        .fold(String::new(), |mut acc, (i, digit)| {
+            if i > 0 && i % 3 == 0 {
+                acc.push(',');
+            }
+            acc.push(digit);
+            acc
+        })
+        .chars()
+        .rev()
+        .collect::<String>()
+        + &number_str[dot_index..];
 
     result
 }

--- a/src/words_to_number/constants.rs
+++ b/src/words_to_number/constants.rs
@@ -50,8 +50,6 @@ pub(super) static MAGNITUDE: &[(&str, i64)] = &[
     ("تریلیون", 1000000000000),
 ];
 
-// pub(super) static ALL_WORDS: &[(&str, i64)] = UNITS.iter().chain(MAGNITUDE.iter());
-
 pub(super) fn get_unit_number(unit: &str) -> Option<&i64> {
     let result = UNITS
         .iter()


### PR DESCRIPTION
I've enhanced the `arabic_chars` module in the following ways:

- Removed the unused `AR_NUMBER`.
- Eliminated the chars child module and now utilize `AR_TEXT` as a constant.

Additionally, I've revamped the `add_commas` functionality:

- Improved the readability of the `add_commas` function.
- Reduced reliance on filtering and iteration for a more concise implementation.

Moreover, I've eliminated a lingering commented code in `constant.rs` within the `words_to_number` module that had been overlooked and needed removal.