### PR TITLE
refactor persian_chars & remove_ordinal_suffix modules

### DIFF
--- a/src/persian_chars/mod.rs
+++ b/src/persian_chars/mod.rs
@@ -1,11 +1,6 @@
 use std::borrow::Cow;
 
 pub mod chars {
-    pub static FA_ALPHABET: &str = "ابپتثجچحخدذرزژسشصضطظعغفقکگلمنوهی";
-    pub static FA_NUMBER: &str = "۰۱۲۳۴۵۶۷۸۹";
-    pub static FA_SHORT_VOWELS: &str = "َُِ";
-    pub static FA_OTHERS: &str = "‌آاً";
-    pub static FA_MIXED_WITH_ARABIC: &str = "ًٌٍَُِّْٰٔءك‌ةۀأإيـئؤ،";
     pub static FA_TEXT: &str = "ابپتثجچحخدذرزژسشصضطظعغفقکگلمنوهی۰۱۲۳۴۵۶۷۸۹َُِ‌آاً؟ ";
     pub static FA_COMPLEX_TEXT: &str = "ابپتثجچحخدذرزژسشصضطظعغفقکگلمنوهی۰۱۲۳۴۵۶۷۸۹َُِ‌آأًًٌٍَُِّْٰءك‌ةۀأإيـئؤ،؟ ";
 }

--- a/src/remove_ordinal_suffix/mod.rs
+++ b/src/remove_ordinal_suffix/mod.rs
@@ -10,21 +10,17 @@ where
 
     if word.ends_with("مین") {
         word = word[0..word.len() - ("مین".len())].to_string()
-    }
-    if word.ends_with("اُم") {
+    } else if word.ends_with("اُم") {
         word = word[0..word.len() - ("اُم".len())].trim().to_string()
-    }
-    if word.ends_with("ام") {
+    } else if word.ends_with("ام") {
         word = word[0..word.len() - ("ام".len())].trim().to_string()
-    }
-
-    if word.ends_with("سوم") {
+    } else if word.ends_with("سوم") {
         word = word[0..word.len() - ("سوم".len())].to_string();
         word += "سه";
-    }
-    if word.ends_with('م') {
+    } else if word.ends_with('م') {
         word = word[0..word.len() - ("م".len())].to_string()
     }
+
     word
 }
 


### PR DESCRIPTION
persian_chars:

- Removed 5 unused variables.

remove_ordinal_suffix:

- Replaced if statements with else if statements to enhance matching speed.
- Addressed an issue where the final if statement `word.ends_with('م')` was inadvertently capturing previous if statements such as `ends_with("اُم")`. The modification ensures more precise matching and avoids unintended captures.