### PR TITLE
chage categories to match https://crates.io/category_slugs fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,22 @@ readme = "README.md"
 # documentation = "https://docs.rs/rust-persian-tools" # if not set docs.rs will generate one and put it in place 
 homepage = "https://crates.io/crates/rust-persian-tools"
 repository = "https://github.com/persian-tools/rust-persian-tools"
-categories = ["localization", "languages", "internationalization", "tools"]
-keywords = ["iran", "persian", "farsi", "tools"]
-include = ["src/**/*.rs", "Cargo.toml", "LICENSE", "README.md", "Contributing.md", "logo.png"]
+categories = [
+    "localization",
+    "text-processing",
+    "internationalization",
+    "development-tools",
+    "rust-patterns",
+]
+keywords = ["iran", "persian", "farsi", "tools", "text-processing"]
+include = [
+    "src/**/*.rs",
+    "Cargo.toml",
+    "LICENSE",
+    "README.md",
+    "Contributing.md",
+    "logo.png",
+]
 
 
 [dependencies]


### PR DESCRIPTION
base on the[ manifest-format  ](https://doc.rust-lang.org/cargo/reference/manifest.html#the-categories-field) for categories field of rust crates.categories field must match with those that has been mentioned in [here](https://crates.io/category_slugs).
so i changed the `cargo.toml` categories field based on these information. 
in addition because this project is about proccessing text so i add another string in `keywords`  to help finding the package easier.